### PR TITLE
Prevented application break due to error

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -78,6 +78,9 @@
                     </linecontainsregexp>
                     <tokenfilter>
                         <scriptfilter language="javascript">with (new JavaImporter(java.net, java.io)) {
+                            var echo = project.createTask("echo");
+
+                            try{
                             var outPath = '@{outPath}';
                             var metadataType = self.getToken();
                             var dir = outPath + '/' + metadataType;
@@ -99,6 +102,10 @@
                             bulkRetrieve.setBatchSize(batchSize);
                             bulkRetrieve.setUnzip(false);
                             bulkRetrieve.perform();
+                            }catch(err){
+                                echo.setMessage(err);
+                                echo.perform();
+                            }
                         }</scriptfilter>
                     </tokenfilter>
                 </filterchain>


### PR DESCRIPTION
There can be error due to unsupported character in name of Metadata like( apostrophe, double quotes). So this will make sure that entire application can't halt there, it skips error metadata retrieval and process for next metadata.